### PR TITLE
Add returnable test result from UnitRunner

### DIFF
--- a/src/TestsResult.php
+++ b/src/TestsResult.php
@@ -4,7 +4,67 @@ declare(strict_types=1);
 
 namespace Umodi;
 
-class TestsResult
+final class TestsResult
 {
+    public int $tests = 0;
+    public int $assertions = 0;
 
+    /** @var array<string, int> */
+    private array $testsByResolution = [];
+    private AssertResolution $worstResolution;
+
+    public function __construct()
+    {
+        foreach (AssertResolution::cases() as $resolution) {
+            $this->testsByResolution[$resolution->value] = 0;
+        }
+
+        $this->worstResolution = AssertResolution::Success;
+    }
+
+    public function registerTestResult(AssertResolution $resolution, int $assertionsCount): void
+    {
+        $this->tests++;
+        $this->assertions += $assertionsCount;
+        $this->testsByResolution[$resolution->value] ??= 0;
+        $this->testsByResolution[$resolution->value]++;
+
+        if ($this->severity($resolution) > $this->severity($this->worstResolution)) {
+            $this->worstResolution = $resolution;
+        }
+    }
+
+    public function testsFor(AssertResolution $resolution): int
+    {
+        return $this->testsByResolution[$resolution->value] ?? 0;
+    }
+
+    public function worstResolution(): AssertResolution
+    {
+        return $this->worstResolution;
+    }
+
+    public function hasFailures(): bool
+    {
+        return $this->testsFor(AssertResolution::Failed) > 0
+            || $this->testsFor(AssertResolution::Error) > 0;
+    }
+
+    public function exitCode(): int
+    {
+        return $this->hasFailures() ? 1 : 0;
+    }
+
+    private function severity(AssertResolution $resolution): int
+    {
+        return match ($resolution) {
+            AssertResolution::Success => 0,
+            AssertResolution::Skipped => 1,
+            AssertResolution::Incomplete => 2,
+            AssertResolution::Warning => 3,
+            AssertResolution::Failed => 4,
+            AssertResolution::Error => 5,
+            AssertResolution::Risky => 6,
+        };
+    }
 }


### PR DESCRIPTION
## Summary
- add a TestsResult value object to aggregate counts and severities for executed tests
- make UnitRunner::run() build and return the TestsResult so callers can use the summary in CLI contexts
- expose helpers for computing per-test resolution and tracking the most severe outcome

## Testing
- php -l src/TestsResult.php
- php -l src/UnitRunner.php

------
https://chatgpt.com/codex/tasks/task_b_68d6a442dc548327a96ad8b9c08594ca