### PR TITLE
Reorganize assertion helpers into domain namespaces

### DIFF
--- a/example-tests/TestExampleController.php
+++ b/example-tests/TestExampleController.php
@@ -10,7 +10,7 @@ use Umodi\Attribute\Skipped;
 use Umodi\Exception\TestPreconditionFailedException;
 use Umodi\Unit;
 use function Umodi\Assert\Browser\statusOk;
-use function Umodi\Assert\isTrue;
+use function Umodi\Assert\Boolean\isTrue;
 use function Umodi\unit;
 
 unit('Bulk post archive', static function (Unit $unit, EntityManagerInterface $em, KernelBrowser $browser) {

--- a/src/Assert/Array/Contains.php
+++ b/src/Assert/Array/Contains.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Array;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param iterable<mixed>|string $haystack
+ */
+function contains(mixed $needle, iterable|string $haystack): AssertResult
+{
+    if (is_string($haystack)) {
+        $success = str_contains($haystack, (string) $needle);
+        $message = sprintf(
+            'Expected string %s to contain %s',
+            var_export($haystack, true),
+            var_export($needle, true),
+        );
+
+        return new AssertResult(
+            $success ? AssertResolution::Success : AssertResolution::Failed,
+            $message,
+        );
+    }
+
+    $success = false;
+
+    foreach ($haystack as $value) {
+        if ($value === $needle) {
+            $success = true;
+            break;
+        }
+    }
+
+    $message = sprintf(
+        'Expected collection to contain %s',
+        var_export($needle, true),
+    );
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        $message,
+    );
+}

--- a/src/Assert/Array/Count.php
+++ b/src/Assert/Array/Count.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Umodi\Assert;
+namespace Umodi\Assert\Array;
 
 use Countable;
 use Umodi\AssertResolution;
@@ -10,10 +10,12 @@ use Umodi\AssertResult;
 
 function count(int $expected, Countable|array $actual): AssertResult
 {
+    $actualCount = \count($actual);
+
     return new AssertResult(
-        $expected === \count($actual)
+        $expected === $actualCount
             ? AssertResolution::Success
             : AssertResolution::Failed,
-        sprintf('Expected %d items, got %d', \count($actual), $expected)
+        sprintf('Expected %d items, got %d', $expected, $actualCount)
     );
 }

--- a/src/Assert/Array/HasKey.php
+++ b/src/Assert/Array/HasKey.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Array;
+
+use ArrayAccess;
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param array<array-key, mixed>|ArrayAccess<array-key, mixed> $actual
+ */
+function hasKey(int|string $key, array|ArrayAccess $actual): AssertResult
+{
+    $exists = is_array($actual)
+        ? array_key_exists($key, $actual)
+        : $actual->offsetExists($key);
+
+    return new AssertResult(
+        $exists ? AssertResolution::Success : AssertResolution::Failed,
+        sprintf('Expected key %s to exist', var_export($key, true)),
+    );
+}

--- a/src/Assert/Boolean/IsFalse.php
+++ b/src/Assert/Boolean/IsFalse.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Umodi\Assert;
+namespace Umodi\Assert\Boolean;
 
 use Umodi\AssertResolution;
 use Umodi\AssertResult;
 
-function isTrue(mixed $actual): AssertResult
+function isFalse(mixed $actual): AssertResult
 {
     return new AssertResult(
-        $actual === true
+        $actual === false
             ? AssertResolution::Success
             : AssertResolution::Failed,
-        sprintf('Expected `true`, actual `%s`', $actual),
+        sprintf('Expected `false`, actual %s', var_export($actual, true)),
     );
 }

--- a/src/Assert/Boolean/IsTrue.php
+++ b/src/Assert/Boolean/IsTrue.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Boolean;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+function isTrue(mixed $actual): AssertResult
+{
+    return new AssertResult(
+        $actual === true
+            ? AssertResolution::Success
+            : AssertResolution::Failed,
+        sprintf('Expected `true`, actual %s', var_export($actual, true)),
+    );
+}

--- a/src/Assert/Comparison/Eq.php
+++ b/src/Assert/Comparison/Eq.php
@@ -2,17 +2,23 @@
 
 declare(strict_types=1);
 
-namespace Umodi\Assert;
+namespace Umodi\Assert\Comparison;
 
 use Umodi\AssertResolution;
 use Umodi\AssertResult;
 
 function eq(mixed $expected, mixed $actual): AssertResult
 {
+    $message = sprintf(
+        'Expected %s, got %s',
+        var_export($expected, true),
+        var_export($actual, true),
+    );
+
     return new AssertResult(
         $expected === $actual
             ? AssertResolution::Success
             : AssertResolution::Failed,
-        sprintf('Expected %d, got %d', $expected, $actual),
+        $message,
     );
 }

--- a/src/Assert/Emptiness/IsEmpty.php
+++ b/src/Assert/Emptiness/IsEmpty.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Emptiness;
+
+use Countable;
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param Countable|array|string $actual
+ */
+function isEmpty(Countable|array|string $actual): AssertResult
+{
+    if (is_string($actual)) {
+        $success = $actual === '';
+        $message = sprintf('Expected empty string, got %s', var_export($actual, true));
+
+        return new AssertResult(
+            $success ? AssertResolution::Success : AssertResolution::Failed,
+            $message,
+        );
+    }
+
+    $count = \count($actual);
+    $success = $count === 0;
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        'Expected value to be empty',
+    );
+}

--- a/src/Assert/Emptiness/NotEmpty.php
+++ b/src/Assert/Emptiness/NotEmpty.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Emptiness;
+
+use Countable;
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param Countable|array|string $actual
+ */
+function notEmpty(Countable|array|string $actual): AssertResult
+{
+    if (is_string($actual)) {
+        $success = $actual !== '';
+        $message = 'Expected string not to be empty';
+
+        return new AssertResult(
+            $success ? AssertResolution::Success : AssertResolution::Failed,
+            $message,
+        );
+    }
+
+    $count = \count($actual);
+    $success = $count > 0;
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        'Expected value not to be empty',
+    );
+}

--- a/src/Assert/Null/IsNull.php
+++ b/src/Assert/Null/IsNull.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Null;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+function isNull(mixed $actual): AssertResult
+{
+    return new AssertResult(
+        $actual === null
+            ? AssertResolution::Success
+            : AssertResolution::Failed,
+        sprintf('Expected `null`, actual %s', var_export($actual, true)),
+    );
+}

--- a/src/Assert/Null/NotNull.php
+++ b/src/Assert/Null/NotNull.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Null;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+function notNull(mixed $actual): AssertResult
+{
+    return new AssertResult(
+        $actual !== null
+            ? AssertResolution::Success
+            : AssertResolution::Failed,
+        'Did not expect `null` value',
+    );
+}

--- a/src/Assert/Numeric/Between.php
+++ b/src/Assert/Numeric/Between.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Numeric;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param int|float $min
+ * @param int|float $max
+ * @param int|float $actual
+ */
+function between(int|float $min, int|float $max, int|float $actual, bool $inclusive = true): AssertResult
+{
+    $success = $inclusive
+        ? ($actual >= $min && $actual <= $max)
+        : ($actual > $min && $actual < $max);
+
+    $message = sprintf(
+        'Expected %s to be %s %s and %s',
+        var_export($actual, true),
+        $inclusive ? 'between' : 'strictly between',
+        var_export($min, true),
+        var_export($max, true),
+    );
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        $message,
+    );
+}

--- a/src/Assert/Numeric/GreaterThan.php
+++ b/src/Assert/Numeric/GreaterThan.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Numeric;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param int|float $expectedLowerBound
+ * @param int|float $actual
+ */
+function greaterThan(int|float $expectedLowerBound, int|float $actual): AssertResult
+{
+    $success = $actual > $expectedLowerBound;
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        sprintf(
+            'Expected %s to be greater than %s',
+            var_export($actual, true),
+            var_export($expectedLowerBound, true),
+        ),
+    );
+}

--- a/src/Assert/Numeric/LessThan.php
+++ b/src/Assert/Numeric/LessThan.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Numeric;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param int|float $expectedUpperBound
+ * @param int|float $actual
+ */
+function lessThan(int|float $expectedUpperBound, int|float $actual): AssertResult
+{
+    $success = $actual < $expectedUpperBound;
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        sprintf(
+            'Expected %s to be less than %s',
+            var_export($actual, true),
+            var_export($expectedUpperBound, true),
+        ),
+    );
+}

--- a/src/Assert/Type/IsInstanceOf.php
+++ b/src/Assert/Type/IsInstanceOf.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Umodi\Assert\Type;
+
+use Umodi\AssertResolution;
+use Umodi\AssertResult;
+
+/**
+ * @param class-string $expected
+ */
+function isInstanceOf(string $expected, object $actual): AssertResult
+{
+    $success = \is_a($actual, $expected);
+
+    return new AssertResult(
+        $success ? AssertResolution::Success : AssertResolution::Failed,
+        sprintf(
+            'Expected instance of %s, got %s',
+            $expected,
+            $actual::class,
+        ),
+    );
+}


### PR DESCRIPTION
## Summary
- move numeric assertions into the Umodi\Assert\Numeric namespace
- group array, boolean, null, emptiness, type, and comparison helpers into dedicated namespaces
- update example test imports to reference the new boolean assertion namespace

## Testing
- find src -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68d6a50f52bc83278745ff555dac7c9d